### PR TITLE
FEATURE: alternative search mode without regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ So if you want to only search pdf files use
 
 ```Test pdf```
 
+### Keyboard navigation
 
+F1 focuses on "file filter", F2 on "search in directory" and F3 on the results list
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,6 +10,50 @@ or use the Command Palette to run the `Search` command.
 
 On Macs's, you can use Spotlight to search for files and text within files.
 
+### "use regex" checkbox
+When checked you can search your files with regex syntax.
+
+*Examples for "file filter"*
+
+All files
+
+```*.*```
+
+Pdf files
+
+```*.pdf```
+
+All files containing "Test"
+
+```*Test*```
+
+All files starting with "Test"
+
+```Test*```
+
+With "use regex" unchecked the filename needs to contain every word you type (separated with a space).
+
+Case will be ignored.
+
+*Examples for "file filter"*
+
+All files containing "Test"
+
+```Test```
+
+All files containing "Test" and "final"
+
+```Test final```
+
+Note that this mode will also search the extension of the file.
+
+So if you want to only search pdf files use
+
+```Test pdf```
+
+
+
+
 ## Installation
 Use fman's
 [built-in command for installing plugins](https://fman.io/docs/installing-plugins).

--- a/gui/searchdialog.py
+++ b/gui/searchdialog.py
@@ -169,8 +169,8 @@ class SearchDialog(QDialog):
 		self.stopButton = QPushButton("Sto&p")
 		self.stopButton.clicked.connect(self.stopButtonClicked)
 		
-		self.showInFmanButton = QPushButton("show results in &fman pane")
-		self.showInFmanButton.clicked.connect(self.showInFman)
+		#self.showInFmanButton = QPushButton("show results in &fman pane")
+		#self.showInFmanButton.clicked.connect(self.showInFman)
 		
 		
 		self.messageLabel = QLabel('')
@@ -215,8 +215,8 @@ class SearchDialog(QDialog):
 		buttonBoxLayout.addWidget(self.cancelButton)
 		buttonBoxLayout.addWidget(self.searchButton)
 		buttonBoxLayout.addWidget(self.stopButton)
-		buttonBoxLayout.addWidget(self.showInFmanButton)
-		
+		#buttonBoxLayout.addWidget(self.showInFmanButton)
+				
 		self.layout.addLayout(buttonBoxLayout)
 		
 		self.buttonMode(BUTTON_MODE_FOR_SEARCHING)

--- a/gui/searchdialog.py
+++ b/gui/searchdialog.py
@@ -65,6 +65,7 @@ class SearchDialog(QDialog):
 	def initUI(self):
 		self.resize(1000, 400)
 		self.setWindowTitle(self.title)
+		self.setWindowFlags(QtCore.Qt.Window)
 
 	def createUI(self):
 		self.layout = QVBoxLayout(self)

--- a/gui/searchdialog.py
+++ b/gui/searchdialog.py
@@ -105,8 +105,11 @@ class SearchDialog(QDialog):
 		self.searchSubDirLevelText.setInputMask('99')
 		
 		self.includeDirectoriesCheckBox = QCheckBox('include directories in fileslist')
+
+		self.includeRegexModeCheckBox = QCheckBox('use regex')
 		
 		subdirsHBoxLayout.addWidget(self.includeDirectoriesCheckBox)
+		subdirsHBoxLayout.addWidget(self.includeRegexModeCheckBox)
 		subdirsHBoxLayout.addStretch(1)
 		
 		subdirsHBoxLayout.addWidget(self.searchSubDirLabel)
@@ -271,6 +274,12 @@ class SearchDialog(QDialog):
 			self.includeDirectoriesCheckBox.setChecked(includedirectoriescheck)
 		except Exception as e:
 			pass	
+
+		try:
+			includegexcheck = self.setup['includegexcheck']
+			self.includeRegexModeCheckBox.setChecked(includegexcheck)
+		except Exception as e:
+			pass		
 			
 		try:
 			encoding = self.setup['encoding']
@@ -434,6 +443,7 @@ class SearchDialog(QDialog):
 			searchSubDirMode = self.searchSubDirButtonGroup.checkedId()
 			searchSubDirLevelText = self.searchSubDirLevelText.text()
 			includeDirectories = self.includeDirectoriesCheckBox.isChecked()
+			includeRegex = self.includeRegexModeCheckBox.isChecked()
 			
 			searchSubDirLevel = 0
 			
@@ -468,7 +478,7 @@ class SearchDialog(QDialog):
 			if len(encoding.strip()) == 0:
 				encoding = 'utf-8'
 				
-			self.searcher = Searcher(directory,pattern,searchText,self.searchStopEvent,searchmode,searchSubDirLevel,includeDirectories,encoding)
+			self.searcher = Searcher(directory,pattern,searchText,self.searchStopEvent,searchmode,searchSubDirLevel,includeDirectories,includeRegex,encoding)
 			self.searchThread = QtCore.QThread()
 			self.searcher.moveToThread(self.searchThread)
 
@@ -668,6 +678,7 @@ class SearchDialog(QDialog):
 		setup['searchsubdirlevel'] 		 = self.searchSubDirLevel.isChecked()
 		setup['searchsubdirleveltext'] 	 = self.searchSubDirLevelText.text()
 		setup['includedirectoriescheck'] = self.includeDirectoriesCheckBox.checkState()
+		setup['includegexcheck'] 		 = self.includeRegexModeCheckBox.checkState()
 		setup['encoding']             	 = self.encodingText.currentText()
 		
 		with open(setupfile, 'w') as outfile:

--- a/gui/searchdialog.py
+++ b/gui/searchdialog.py
@@ -84,7 +84,7 @@ class SearchDialog(QDialog):
 		fileFilterLabel = QLabel('file filter')
 		self.fileFilterText = QComboBox()
 		self.fileFilterText.setEditable(True)
-		
+		self.fileFilterText.lineEdit().returnPressed.connect(self.searchButtonClicked)
 		searchDirLabel = QLabel('search in directory')
 		self.searchDirText = QLineEdit(self.directory)
 		

--- a/gui/searchdialog.py
+++ b/gui/searchdialog.py
@@ -52,23 +52,38 @@ class SearchDialog(QDialog):
 		self.fileNameQueueTimer.start()
 		
 		self.setAttribute(Qt.WA_DeleteOnClose)
-		self.title = 'Search'
+		self.title = 'fman search'
 		
 		self.directory = directory
 		self.fileFilter = ''
 
 		self.setup = self.load_setup(SEARCHSETUP)
-		
+
+
 		self.initUI()
 		self.createUI()
 
+
+	def newOnkeyPressEvent(self, event):	
+		if event.key() == QtCore.Qt.Key_F1:
+			self.fileFilterText.setFocus()
+		elif event.key() == QtCore.Qt.Key_F2:			
+			self.searchDirText.setFocus()
+		elif event.key() == QtCore.Qt.Key_F3:
+			rowIndex = self.searchResultList.currentRow()
+			if rowIndex < 0:
+				rowIndex = 0				
+			self.searchResultList.setCurrentRow(rowIndex)
+			self.searchResultList.setFocus()
+
 	def initUI(self):
-		self.resize(1000, 400)
+		self.resize(1000, 600)
 		self.setWindowTitle(self.title)
 		self.setWindowFlags(QtCore.Qt.Window)
+		self.keyPressEvent = self.newOnkeyPressEvent
 
 	def createUI(self):
-		self.layout = QVBoxLayout(self)
+		self.layout = QVBoxLayout(self)						
 		self.layout.setContentsMargins(0, 0, 0, 0)
 	
 		groupBox = QGroupBox("Search")
@@ -189,6 +204,7 @@ class SearchDialog(QDialog):
 		self.searchResultList = QListWidget()
 		self.layout.addWidget(self.searchResultList)
 		self.searchResultList.itemDoubleClicked.connect(self.onDoubleClickSearchResultList)
+		self.searchResultList.keyPressEvent = self.onKeyPressSearchResultList
 		
 		self.progressBar = QProgressBar(self)
 		self.layout.addWidget(self.progressBar)
@@ -205,8 +221,21 @@ class SearchDialog(QDialog):
 		
 		self.buttonMode(BUTTON_MODE_FOR_SEARCHING)
 		
-		self.preset()
-		
+		self.preset()	
+
+
+	def onKeyPressSearchResultList(self, e):			
+		if e.key() == Qt.Key_Return or e.key() == Qt.Key_Enter:
+			fullname = self.searchResultList.currentItem().text()
+			path,filename = os.path.split(os.path.abspath(fullname))
+			if not filename == '':				
+				def callback():
+					self.fman_pane.place_cursor_at(as_url(fullname))
+
+				self.fman_pane.set_path(as_url(path),callback)	
+	
+		else:			
+			QListWidget.keyPressEvent(self.searchResultList, e)
 
 	def preset(self):
 		# set from setup
@@ -342,8 +371,9 @@ class SearchDialog(QDialog):
 		self.encodingLabel.setVisible(not enabled)
 		self.encodingText.setVisible(not enabled)
 		
-		self.setTextMode(self.searchCheckBox.isChecked(),True)
-		
+		self.setTextMode(self.searchCheckBox.isChecked(),True)		
+
+
 
 	def onDoubleClickSearchResultList(self,item):
 		fullname = item.text()
@@ -353,9 +383,8 @@ class SearchDialog(QDialog):
 			def callback():
 				self.fman_pane.place_cursor_at(as_url(fullname))
 
-			self.fman_pane.set_path(as_url(path),callback)
+			self.fman_pane.set_path(as_url(path),callback)		
 
-	
 	def closeDialog(self):		
 
 		try:


### PR DESCRIPTION
![Screenshot](https://screens.xida.de/fman_y0BW2b8BN2.jpg "Screenshot")

### "use regex" checkbox
When checked you can search your files with regex syntax.

*Examples for "file filter"*

All files

```*.*```

Pdf files

```*.pdf```

All files containing "Test"

```*Test*```

All files starting with "Test"

```Test*```

With "use regex" unchecked the filename needs to contain every word you type (separated with a space).

Case will be ignored.

*Examples for "file filter"*

All files containing "Test"

```Test```

All files containing "Test" and "final"

```Test final```

Note that this mode will also search the extension of the file.

So if you want to only search pdf files use

```Test pdf```
